### PR TITLE
Add engines to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dts-critic",
-    "version": "2.2.4",
+    "version": "3.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,9 +549,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.0.12",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.12.tgz",
-            "integrity": "sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==",
+            "version": "10.17.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.16.tgz",
+            "integrity": "sha512-A4283YSA1OmnIivcpy/4nN86YlnKRiQp8PYwI2KdPCONEBN093QTb0gCtERtkLyVNGKKIGazTZ2nAmVzQU51zA==",
             "dev": true
         },
         "@types/parsimmon": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
         "eslint-plugin-no-null": "^1.0.2",
         "jest": "^24.7.1",
         "strip-json-comments": "^2.0.1"
+    },
+    "engines": {
+        "node": ">=12.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "devDependencies": {
         "@types/command-exists": "^1.2.0",
         "@types/jest": "^24.0.0",
-        "@types/node": "12.0.x",
+        "@types/node": "~10.17.0",
         "@types/semver": "^6.0.1",
         "@types/strip-json-comments": "0.0.30",
         "@types/yargs": "^12.0.8",
@@ -52,6 +52,6 @@
         "strip-json-comments": "^2.0.1"
     },
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=10.17.0"
     }
 }


### PR DESCRIPTION
Require node >= 12.
I could try to require node >= 10.10, but then we run into [this issue](https://github.com/microsoft/TypeScript/issues/32333) and it seems too much trouble.
This also means having to update the minimum node version in dtslint, types-publisher and DT.