### PR TITLE
Fix detection of export syntax in declaration file

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -640,10 +640,12 @@ function getDtsExportKind(sourceFile: ts.SourceFile): InferenceResult<DtsExportK
     if (matches(sourceFile, isExportEquals)) {
         return inferenceSuccess(DtsExportKind.ExportEquals);
     }
-    if (matches(sourceFile, isExportConstruct)) {
-        return inferenceSuccess(DtsExportKind.ES6Like);
-    }
-    return inferenceError("Could not infer export kind of declaration file.");
+    return inferenceSuccess(DtsExportKind.ES6Like);
+    // if (matches(sourceFile, isExportConstruct)) {
+    //     return inferenceSuccess(DtsExportKind.ES6Like);
+    // }
+    // // try get declare module, return eslike if so
+    // return inferenceError("Could not infer export kind of declaration file.");
 }
 
 const exportEqualsSymbolName = "export=";

--- a/index.ts
+++ b/index.ts
@@ -641,11 +641,6 @@ function getDtsExportKind(sourceFile: ts.SourceFile): InferenceResult<DtsExportK
         return inferenceSuccess(DtsExportKind.ExportEquals);
     }
     return inferenceSuccess(DtsExportKind.ES6Like);
-    // if (matches(sourceFile, isExportConstruct)) {
-    //     return inferenceSuccess(DtsExportKind.ES6Like);
-    // }
-    // // try get declare module, return eslike if so
-    // return inferenceError("Could not infer export kind of declaration file.");
 }
 
 const exportEqualsSymbolName = "export=";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dts-critic",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
When we inspect a declaration file, we try to decide if it uses `export =` syntax or named/default ("normal") exports.  To do this, we were looking for export constructs in the AST.  If we fail to find any export construct, then we stop (with an `inferenceFailure`) and don't proceed to infer the type of the module and so we don't perform any further checks.
However, if there's no explicit export keyword or statement, every declaration is considered as exported. So in cases where there's no explicit export, we don't check for instance if the properties exported from the JS match the d.ts.
This PR changes the code to always consider that we're dealing with "normal" exports if we don't find an `export =`, so we're able to perform further checks for more packages.
The observable result should be that we're able to perform the "JsPropertyNotInDts" check for more packages, which only changes the suggestions provided and doesn't interfere with linting, but it would be nice to test this and future PRs using dtslint-runner before merging and publishing.