### PR TITLE
Use tmp for npm downloads

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,6 @@ import fs = require("fs");
 import cp = require("child_process");
 import path = require("path");
 import semver = require("semver");
-import rimraf = require("rimraf");
 import { sync as commandExistsSync } from "command-exists";
 import ts from "typescript";
 import * as tmp from "tmp";
@@ -110,12 +109,7 @@ If you want to check the declaration against the JavaScript source code, you mus
                 packagePath = downloadNpmPackage(name, npmVersion, tempDirName)
                 sourceEntry = require.resolve(path.resolve(packagePath));
             }
-            const errors = checkSource(name, dtsPath, sourceEntry, options.errors, debug);
-            if (packagePath) {
-                // Delete the source afterward to avoid running out of space
-                rimraf.sync(packagePath)
-            }
-            return errors;
+            return checkSource(name, dtsPath, sourceEntry, options.errors, debug);
         }
 
         return [];

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import semver = require("semver");
 import rimraf = require("rimraf");
 import { sync as commandExistsSync } from "command-exists";
 import ts from "typescript";
+import * as tmp from "tmp";
 
 export enum ErrorKind {
     /** Declaration is marked as npm in header and has no matching npm package. */
@@ -105,7 +106,8 @@ If you want to check the declaration against the JavaScript source code, you mus
                 sourceEntry = sourcePath;
             }
             else {
-                packagePath = downloadNpmPackage(name, npmVersion, sourceDir)
+                const tempDirName = tmp.dirSync({ unsafeCleanup: true }).name
+                packagePath = downloadNpmPackage(name, npmVersion, tempDirName)
                 sourceEntry = require.resolve(path.resolve(packagePath));
             }
             const errors = checkSource(name, dtsPath, sourceEntry, options.errors, debug);

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,23 +532,6 @@
             "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
             "dev": true
         },
-        "@types/events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-            "dev": true
-        },
-        "@types/glob": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-            "dev": true,
-            "requires": {
-                "@types/events": "*",
-                "@types/minimatch": "*",
-                "@types/node": "*"
-            }
-        },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -589,12 +572,6 @@
             "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
             "dev": true
         },
-        "@types/minimatch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-            "dev": true
-        },
         "@types/node": {
             "version": "10.17.16",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.16.tgz",
@@ -605,16 +582,6 @@
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.1.tgz",
             "integrity": "sha512-MoF2IC9oGSgArJwlxdst4XsvWuoYfNUWtBw0kpnCi6K05kV+Ecl7siEeJ40tgCbI9uqEMGQL/NlPMRv6KVkY5Q=="
-        },
-        "@types/rimraf": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz",
-            "integrity": "sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==",
-            "dev": true,
-            "requires": {
-                "@types/glob": "*",
-                "@types/node": "*"
-            }
         },
         "@types/semver": {
             "version": "6.2.1",
@@ -637,7 +604,8 @@
         "@types/tmp": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
-            "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ=="
+            "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+            "dev": true
         },
         "@types/yargs": {
             "version": "12.0.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -634,6 +634,11 @@
             "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
             "dev": true
         },
+        "@types/tmp": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
+            "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ=="
+        },
         "@types/yargs": {
             "version": "12.0.16",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.16.tgz",
@@ -2040,6 +2045,17 @@
                 "chardet": "^0.7.0",
                 "iconv-lite": "^0.4.24",
                 "tmp": "^0.0.33"
+            },
+            "dependencies": {
+                "tmp": {
+                    "version": "0.0.33",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+                    "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+                    "dev": true,
+                    "requires": {
+                        "os-tmpdir": "~1.0.2"
+                    }
+                }
             }
         },
         "extglob": {
@@ -5926,12 +5942,11 @@
             "dev": true
         },
         "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "rimraf": "^3.0.0"
             }
         },
         "tmpl": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "command-exists": "^1.2.8",
         "rimraf": "^3.0.2",
         "semver": "^6.2.0",
+        "tmp": "^0.2.1",
         "typescript": "^3.9.2",
         "yargs": "^12.0.5"
     },
@@ -41,6 +42,7 @@
         "@types/rimraf": "^3.0.0",
         "@types/semver": "^6.0.1",
         "@types/strip-json-comments": "0.0.30",
+        "@types/tmp": "^0.2.0",
         "@types/yargs": "^12.0.8",
         "@typescript-eslint/eslint-plugin": "^2.3.2",
         "@typescript-eslint/experimental-utils": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@definitelytyped/header-parser": "0.0.34",
         "command-exists": "^1.2.8",
-        "rimraf": "^3.0.2",
         "semver": "^6.2.0",
         "tmp": "^0.2.1",
         "typescript": "^3.9.2",
@@ -39,7 +38,6 @@
         "@types/command-exists": "^1.2.0",
         "@types/jest": "^24.0.0",
         "@types/node": "~10.17.0",
-        "@types/rimraf": "^3.0.0",
         "@types/semver": "^6.0.1",
         "@types/strip-json-comments": "0.0.30",
         "@types/tmp": "^0.2.0",


### PR DESCRIPTION
This stops dts-critic from leaving tgz droppings all over.

Additionally, I pass `unsafeCleanup: true` so that the directory is deleted afterward. That means I can take the manual package deletion code out since
it will be deleted when the process finishes.

Fixes #26