### PR TITLE
ignore webpack's single-letter properties

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -99,6 +99,15 @@ The JavaScript module exports a property named 'foo', which is missing from the 
             }
         ]));
     },
+    noMissingWebpackProperty() {
+        expect(checkSource(
+            "missingJsProperty",
+            "testsource/webpackPropertyNames.d.ts",
+            "testsource/webpackPropertyNames.js",
+            allErrors,
+            false,
+        )).toHaveLength(0);
+    },
     missingDtsProperty() {
         expect(checkSource(
             "missingDtsProperty",

--- a/index.ts
+++ b/index.ts
@@ -703,7 +703,7 @@ function getDtsDefaultExport(sourceFile: ts.SourceFile, moduleType: InferenceRes
     return undefined;
 }
 
-const ignoredProperties = ["__esModule", "prototype", "default"];
+const ignoredProperties = ["__esModule", "prototype", "default", "F", "G", "S", "P", "B", "W", "U", "R"];
 
 function ignoreProperty(property: ts.Symbol): boolean {
     const name = property.getName();

--- a/testsource/webpackPropertyNames.d.ts
+++ b/testsource/webpackPropertyNames.d.ts
@@ -1,0 +1,1 @@
+export var normal: string;

--- a/testsource/webpackPropertyNames.js
+++ b/testsource/webpackPropertyNames.js
@@ -1,0 +1,12 @@
+var $export = {};
+// type bitmap
+$export.F = 1;   // forced
+$export.G = 2;   // global
+$export.S = 4;   // static
+$export.P = 8;   // proto
+$export.B = 16;  // bind
+$export.W = 32;  // wrap
+$export.U = 64;  // safe
+$export.R = 128; // real proto method for `library`
+$export.normal = "hi";
+module.exports = $export;


### PR DESCRIPTION
Fixes #27 

Nothing fancy, just skips them -- I don't think it's a problem to over-squelch in this case.