### PR TITLE
Do not squelch tar warnings on macOS

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import yargs = require("yargs");
 import headerParser = require("@definitelytyped/header-parser");
 import fs = require("fs");
+import os = require("os")
 import cp = require("child_process");
 import path = require("path");
 import semver = require("semver");
@@ -320,7 +321,10 @@ function downloadNpmPackage(name: string, version: string, outDir: string): stri
     const tarballName: string = npmPackOut.filename;
     const outPath = path.join(outDir, name);
     initDir(outPath);
-    cp.execFileSync("tar", ["-xz", "-f", tarballName, "-C", outPath, "--warning=none"], cpOpts);
+    const args = os.platform() === "darwin"
+      ? ["-xz", "-f", tarballName, "-C", outPath]
+      : ["-xz", "-f", tarballName, "-C", outPath, "--warning=none"];
+    cp.execFileSync("tar", args, cpOpts);
     fs.unlinkSync(tarballName);
     return path.join(outPath, getPackageDir(outPath));
 }


### PR DESCRIPTION
1. BSD tar doesn't support `--warnings`.
2. The only reason dts-critic suppresses warnings is that GNU tar issues
them when unpacking tar files created on macOS. BSD tar doesn't issue
these warnings as far as I know.

I haven't tested this change because I don't have a macOS machine set up
for development.