### PR TITLE
Support npm v7

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -316,9 +316,7 @@ function downloadNpmPackage(name: string, version: string, outDir: string): stri
     const npmName = dtToNpmName(name);
     const fullName = `${npmName}@${version}`;
     const cpOpts = { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 } as const;
-    const npmPack = cp.execFileSync("npm", ["pack", fullName, "--json", "--silent"], cpOpts);
-    const npmPackOut = JSON.parse(npmPack)[0];
-    const tarballName: string = npmPackOut.filename;
+    const tarballName = cp.execFileSync("npm", ["pack", fullName, "--silent"], cpOpts).slice(0, -1);
     const outPath = path.join(outDir, name);
     initDir(outPath);
     const args = os.platform() === "darwin"


### PR DESCRIPTION
Looks like the `npm pack --json` option [was dropped](https://github.com/npm/cli/commit/108a4fcb5da23c34690b4767a4c5f7f93ab99c0d#diff-eabad0b45ec780b8b57ae6e3d47fd7d063680bea3acdc6b98a4b45ba3b808cccL32) in v7? https://travis-ci.org/github/microsoft/dtslint/builds/741756441#L202

Oh well, all we used it for was the tarball name, anyway.