### PR TITLE
Work around npm pack issue with scoped packages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -317,7 +317,13 @@ function downloadNpmPackage(name: string, version: string, outDir: string): stri
     const fullName = `${npmName}@${version}`;
     const cpOpts = { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 } as const;
     const npmPack = cp.execFileSync("npm", ["pack", fullName, "--json", "--silent"], cpOpts).trim();
-    const tarballName = npmPack.endsWith(".tgz") ? npmPack : JSON.parse(npmPack)[0].filename as string;
+    let tarballName = npmPack.endsWith(".tgz") ? npmPack : JSON.parse(npmPack)[0].filename as string;
+    
+    // Npm does not report the correct filename for scoped packages. See https://github.com/npm/cli/issues/3405.
+    if ( ! fs.existsSync( tarballName ) ) {
+        tarballName = tarballName.replace(/^@/, '').replace(/\//, '-');
+    }
+
     const outPath = path.join(outDir, name);
     initDir(outPath);
     const args = os.platform() === "darwin"


### PR DESCRIPTION
Resolves #46

Currently, it is not possible to run `npm test @namespace/package` locally for DefinitelyTyped (see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/56042). The error is a bug in `npm`, where it gives the incorrect filename for packed packages:

```
# Reported filename:
npm pack @wordpress/data-controls
# npm notice filename:      @wordpress/data-controls-2.2.6.tgz

# Actual filename:
ls
# wordpress-data-controls-2.2.6.tgz
```

Specifically, npm strips the leading `@` and removes the `/` for the file it saves, but doesn't apply those changes to the filename it reports.

Dts critic relies on `npm pack`'s reported filename. To work around this problem, if the downloaded tarball can't be found, we do the string replacement ourselves as a backup.